### PR TITLE
Add OSGi metadata

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,6 +10,7 @@ plugins {
   id 'ru.vyarus.animalsniffer' version '1.5.3'
   id "io.github.gradle-nexus.publish-plugin" version "1.0.0"
   id "org.moditect.gradleplugin" version "1.0.0-rc3"
+  id "biz.aQute.bnd.builder" version "6.4.0"
 }
 
 repositories {
@@ -77,6 +78,19 @@ addMainModuleInfo {
 java {
 	withJavadocJar()
 	withSourcesJar()
+}
+
+jar {
+  // Add minimal OSGi metadata.
+  // We are using slf4j as a client, so can use also 2.x API.
+  bundle {
+    bnd '''
+Bundle-SymbolicName: ${project.group}.${project.name}
+Import-Package: org.slf4j;version="[1.7,3)", *
+-exportcontents: *
+-noextraheaders: true
+'''
+  }
 }
 
 // This disables the pedantic doclint feature of JDK8


### PR DESCRIPTION
Use bnd plugin to generate minimum MANIFEST.MF entries to make the jar
a proper bundle. This makes the jar readily useable in OSGi environments
without having to resort to wrapping.

Signed-off-by: Robert Varga <robert.varga@pantheon.tech>
